### PR TITLE
Start with fresh sentinel.conf to ignore redis auto-generated conf fields

### DIFF
--- a/scripts/redis/sentinel/sentinel.sh
+++ b/scripts/redis/sentinel/sentinel.sh
@@ -75,7 +75,9 @@ if [[ ! -f /data/sentinel.conf ]]; then
     setSentinelConf
     exec redis-sentinel /data/sentinel.conf $args
 else
-    log "DATA" "loading from raw conf"
+    log "DATA" "Creating fresh sentinel.conf"
+    cp /scripts/sentinel.conf /data/sentinel.conf
+    setSentinelConf
     exec redis-sentinel /data/sentinel.conf $args &
     pid=$!
     resetSentinel

--- a/scripts/redis/sentinel/sentinel.sh
+++ b/scripts/redis/sentinel/sentinel.sh
@@ -75,7 +75,7 @@ if [[ ! -f /data/sentinel.conf ]]; then
     setSentinelConf
     exec redis-sentinel /data/sentinel.conf $args
 else
-    log "DATA" "Creating fresh sentinel.conf"
+    log "DATA" "loading from /data/sentinel.conf"
     cp /scripts/sentinel.conf /data/sentinel.conf
     setSentinelConf
     exec redis-sentinel /data/sentinel.conf $args &

--- a/scripts/valkey/sentinel/sentinel.sh
+++ b/scripts/valkey/sentinel/sentinel.sh
@@ -75,7 +75,9 @@ if [[ ! -f /data/sentinel.conf ]]; then
     setSentinelConf
     exec valkey-sentinel /data/sentinel.conf $args
 else
-    log "DATA" "loading from raw conf"
+    log "DATA" "loading from /data/sentinel.conf"
+    cp /scripts/sentinel.conf /data/sentinel.conf
+    setSentinelConf
     exec valkey-sentinel /data/sentinel.conf $args &
     pid=$!
     resetSentinel


### PR DESCRIPTION
Problem:
Updating only the requirepass field in sentinel.conf does not take effect as expected. This is because Redis Sentinel generates certain fields in the sentinel.conf file, and these generated fields can override or interfere with the updated requirepass value.

Solution:
To ensure the new password is applied correctly, we remove the previously generated sentinel.conf and generate a fresh configuration file. This prevents Redis Sentinel from starting with the old password due to leftover auto-generated fields.